### PR TITLE
Ensure that the platform.js file is also copied over

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -15,6 +15,8 @@
 	<js-module src="www/apppreferences.js">
 		<clobbers target="plugins.appPreferences" />
 	</js-module>
+	<js-module src="src/platform.js">
+	</js-module>
 
 	<asset src="www/task/AppPreferences.js" target="task/AppPreferences.js" />
 


### PR DESCRIPTION
Otherwise, I get an error at this location:
https://github.com/apla/me.apla.cordova.app-preferences/blob/master/www/apppreferences.js#L5
since the require fails
